### PR TITLE
feat: allow mark tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ module.exports = function sanitizer_plugin(md, options) {
       // <a href="url" title="(optional)"></a>
       patternLinkOpen = '<a\\s([^<>]*href="[^"<>]*"[^<>]*)\\s?>',
       regexpLinkOpen = RegExp(patternLinkOpen, 'i'),
+      // <mark class="classname" js-search-message-id="id">
+      patternMarkdown =
+        '<mark\\sclass="([\\w\\-\\_\\s]*)"\\sjs-search-message-id="(\\w*)">'
+      regexpMarkdown = RegExp(patternMarkdown)
       // <img src="url" alt=""(optional) title=""(optional)>
       patternImage = '<img\\s([^<>]*src="[^"<>]*"[^<>]*)\\s?\\/?>',
       regexpImage = RegExp(patternImage, 'i'),
@@ -24,7 +28,7 @@ module.exports = function sanitizer_plugin(md, options) {
 
 
   var allowedTags = [ 'a', 'b', 'blockquote', 'code', 'em', 'h1', 'h2', 'h3', 'h4', 'h5',
-                     'h6', 'li', 'ol', 'p', 'pre', 's', 'sub', 'sup', 'strong', 'ul' ];
+                     'h6', 'li', 'ol', 'p', 'pre', 's', 'sub', 'sup', 'strong', 'ul', 'mark' ];
   var openTagCount = new Array(allowedTags.length);
   var removeTag = new Array(allowedTags.length);
   for (j = 0; j < allowedTags.length; j++) { openTagCount[j] = 0; }
@@ -74,6 +78,10 @@ module.exports = function sanitizer_plugin(md, options) {
         }
       }
 
+      // markdown
+      match = tag.match(regexpMarkdown)
+      if (match) return tag
+
       // links
       tagnameIndex = allowedTags.indexOf('a');
       match = tag.match(regexpLinkOpen);
@@ -106,7 +114,7 @@ module.exports = function sanitizer_plugin(md, options) {
       }
 
       // whitelisted tags
-      match = tag.match(/<(\/?)(b|blockquote|code|em|h[1-6]|li|ol(?: start="\d+")?|p|pre|s|sub|sup|strong|ul)>/i);
+      match = tag.match(/<(\/?)(b|blockquote|code|em|h[1-6]|li|ol(?: start="\d+")?|p|pre|s|sub|sup|strong|ul|mark)>/i);
       if (match && !/<\/ol start="\d+"/i.test(tag)) {
         runBalancer = true;
         tagnameIndex = allowedTags.indexOf(match[2].toLowerCase().split(' ')[0]);
@@ -166,6 +174,7 @@ module.exports = function sanitizer_plugin(md, options) {
     var blkIdx, inlineTokens;
 
     function replaceUnbalancedTag(str, tagname) {
+      if (tagname === 'mark') return str
       var openingRegexp, closingRegexp;
       if (tagname === 'a') {
         openingRegexp = RegExp('<a href="[^"<>]*" title="[^"<>]*" target="_blank">', 'g');


### PR DESCRIPTION
### Changes

- whitelist `mark` tag and attributes (`class` and `js-message-id`) to facilitate in Taskworld search highlights

<img width="2669" alt="Screenshot 2023-03-17 at 13 46 49" src="https://user-images.githubusercontent.com/107842303/225832790-662c0dd5-f17f-4594-a24c-da4c7e212645.png">
